### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ echo "CREATE TABLE TODO(
 ### Running With Docker
 Run with port 1521 opened, optionally expose port 8080 for apex:
 ```
-docker run -d -p 8080:8080 -p 1521:1521 martinsthiago/oraclexe-11g-fig
+docker run -dt -p 8080:8080 -p 1521:1521 martinsthiago/oraclexe-11g-fig
 ```
 
 ### Running With Fig


### PR DESCRIPTION
In my case there was essentially to enter "-t" -option for "docker run". When not the comman tail in startup.sh fails and the docker container is ended immediately after it started up.